### PR TITLE
Added dolphin.cmd() a variation of dolphin.docker()

### DIFF
--- a/lib/images.js
+++ b/lib/images.js
@@ -17,36 +17,67 @@ module.exports = function (dolphin) {
   }
 
   /**
-   *
-   *  We use docker command line since building images is quite a complex
-   *  operation.
-   *  */
-  images.build = function (url, name, versions, params) {
-    var args = [].concat.apply([], versions.map(function (tag) {
-      return ['-t', name + ':' + tag];
-    }));
-
-    if (params.Labels) {
-      Object.keys(params.Labels).forEach(function (label) {
-        args = args.concat('--label', label + '=' + params.Labels[label]);
-      });
+   * 
+   * @param {string} url 
+   * @param {string} name 
+   * @param {string[]} [versions] 
+   * @param {{Labels?: object; buildargs?: object; }} [params] 
+   * @returns {Promise<{ Id: string }>}
+   */
+  images.build = function (url, name, versions = [], params = {}) {
+    if (typeof url !== 'string') {
+      throw new Error('url needs to be a string');
     }
 
-    if (params.buildargs) {
-      Object.keys(params.buildargs).forEach(function (arg) {
-        args = args.concat('--build-arg', arg + '=' + params.buildargs[arg]);
-      });
+    if (typeof name !== 'string') {
+      throw new Error('name needs to be a string');
     }
 
-    args.unshift('build');
+    if(versions && !Array.isArray(versions)) {
+      throw new Error('versions needs to be an array');
+    }
+
+    const args = ['build'];
+
+    if (versions && versions.length > 0) {
+      for (const version of versions) {
+        args.push('-t', `${name}:${version}`);
+      }
+    } else {
+      // do not use any versions but still use tag
+      args.push('-t', name);
+    }
+
+    if (params) {
+      if(typeof params !== 'object') {
+        throw new Error('params needs to be an object');
+      }
+      
+      for (const param of [
+        { key: 'Labels', arg: '--label' },
+        { key: 'buildargs', arg: '--build-arg' }
+      ]) {
+        const obj = params[param.key];
+
+        if (obj && typeof obj === 'object') {
+          Object
+            .keys(obj)
+            .forEach(key => {
+              args.push(param.arg, `${key}=${obj[key]}`);
+            });
+        }
+      }
+    }
+
     args.push('-q')
     args.push(url);
 
-    return dolphin.docker(args).then(function (imageId) {
+    // We use docker command line since building images is quite a complex operation.
+    return dolphin.cmd(args).then(({ stdout }) => {
       return {
-        Id: imageId.trim()
-      }
-    })
+        Id: stdout.trim()
+      };
+    });
   }
 
   images.push = function (image, tag) {
@@ -57,7 +88,7 @@ module.exports = function (dolphin) {
     return dolphin._post(url, null, opts);
   }
 
-  images.tag = function(nameOrId, repo, tag){
+  images.tag = function (nameOrId, repo, tag) {
     var url = 'images/' + nameOrId + '/tag?repo=' + repo;
     if (tag) {
       url += '&tag=' + tag;
@@ -86,7 +117,7 @@ module.exports = function (dolphin) {
           if (err) return reject(err);
           resolve(body);
         });
-      }else{
+      } else {
         resolve();
       }
     });

--- a/lib/networks.js
+++ b/lib/networks.js
@@ -35,11 +35,11 @@ module.exports = function(dolphin){
     }
     args.push(params.Name);
 
-    return dolphin.docker(args).then(function(networkId){
+    return dolphin.cmd(args).then(({ stdout }) => {
       return {
-        Id: networkId
-      }
-    })
+        Id: stdout.trim()
+      };
+    });
   }
 
   networks.connect = function (containerId) {


### PR DESCRIPTION
The point of this new addition is to not lose information when executing a docker command.

- Not modifying `docker(args)` function to be backward compatible.
- `cmd()` has the signature:
```ts
interface DockerCommandResult {
    readonly stdout: string;
    readonly stderr: string;
}

function cmd(args: string[], cb?: (data: string, err: string) => void) => Promise<DockerCommandResult>;
```
- When a callback function is given, the function is called on every new string received from `stdout` or `stderr`. If an error is in place, the callback is called with `cb(null, err)`. Otherwise, `cb(data)`.
- If a non-zero code is returned, an `Error` is thrown, with four extra fields: `code, signal, stdout, and stderr`. This follows, more or less this signature:
```ts
interface DockerError extends Error implements DockerCommandResult {
    readonly code: number;
    readonly signal: string;

    readonly stdout: string;
    readonly stderr: string;
}
```

Files that were using `dolphin.docker()` were changed to use `dolphin.cmd()`.

Also, fixed `dolphin.images.build()` to not need `versions` or `params`