### PR TITLE
use native http module instead of request dependency

### DIFF
--- a/lib/images.js
+++ b/lib/images.js
@@ -100,22 +100,16 @@ module.exports = function (dolphin) {
   // TODO: registry auth.
   // TODO: default registries, etc.
   //
-  var request = require('request');
   images.manifest = function (name, tag) {
     return new Promise(function (resolve, reject) {
       var splitted = name.split('/');
       if (splitted.length > 1) {
         var registry = splitted[0];
         var repo = splitted[1];
-        var opts = {
-          url: 'https://' + registry + '/v2/' + repo + '/manifests/' + tag,
-          method: 'GET',
-          json: true,
-        }
 
-        request(opts, function (err, response, body) {
+        getJSON('https://' + registry + '/v2/' + repo + '/manifests/' + tag, function (err, data) {
           if (err) return reject(err);
-          resolve(body);
+          resolve(data);
         });
       } else {
         resolve();
@@ -124,4 +118,43 @@ module.exports = function (dolphin) {
   }
 
   return images;
+}
+
+var http = require('http');
+function getJSON(url, callback) {
+  http.get(url, function (res) {
+    var statusCode = res.statusCode;
+    var contentType = res.headers['content-type'];
+
+    var error;
+    if (statusCode !== 200) {
+      error = new Error('Request Failed.\n' +
+        `Status Code: ${statusCode}`);
+
+    } else if (!/^application\/json/.test(contentType)) {
+      error = new Error('Invalid content-type.\n' +
+        `Expected application/json but received ${contentType}`);
+    }
+
+    if (error) {
+      // Consume response data to free up memory
+      res.resume();
+      callback(error.message);
+      return;
+    }
+
+    res.setEncoding('utf8');
+    var rawData = '';
+    res.on('data', (chunk) => { rawData += chunk; });
+    res.on('end', () => {
+      try {
+        callback(undefined, JSON.parse(rawData));
+
+      } catch (e) {
+        callback(e.message);
+      }
+    });
+  }).on('error', (e) => {
+    callback(e.message);
+  });
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "homepage": "https://github.com/OptimalBits/dolphin",
   "dependencies": {
     "bluebird": "^2.9.24",
-    "lodash": "^4.15.0",
-    "request": "^2.65.0"
+    "lodash": "^4.15.0"
   }
 }


### PR DESCRIPTION
I've found [redbird](https://github.com/OptimalBits/redbird) today, and was going to test it, but noticed that `redbird` has too many dependencies. dolphin/request being one of them. 

This pull-request just removes `request`, as it has 20 dependencies only for using GET + JSON parsing.

**See the dependency graph below:**

![Screenshot 2019-03-29 at 15 31 07](https://user-images.githubusercontent.com/130494/55255904-7e2d7580-523a-11e9-97cb-0371d403124a.png)

**And now, without `request`:**

![Screenshot 2019-03-29 at 15 53 18](https://user-images.githubusercontent.com/130494/55256015-ccdb0f80-523a-11e9-8046-e1d3615bd71d.png)
